### PR TITLE
fix the desc of function with a default parameter

### DIFF
--- a/_subpages/functions.md
+++ b/_subpages/functions.md
@@ -75,7 +75,7 @@ print(multiply(x: 5, y: 6)) // 30
 
 ### Function with a default parameter value
 
-This function takes two parameters, both `Ints`, and returns an `Int`.
+This function takes one optional parameter `String`.
 
 {% include opencol.html size=7 newrow=true %}
 


### PR DESCRIPTION
currently, for 'Function with a default parameter value', the description:
This function takes two parameters, both Ints, and returns an Int.
is wrong.